### PR TITLE
✨ [Feat] 오늘의 옷(해시태그) 추천 조회

### DIFF
--- a/src/main/java/com/example/teamB/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/controller/HashtagController.java
@@ -1,0 +1,31 @@
+package com.example.teamB.domain.hashtag.controller;
+
+import com.example.teamB.domain.hashtag.dto.HashtagResponseDTO;
+import com.example.teamB.domain.hashtag.service.query.HashtagQueryService;
+import com.example.teamB.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "Hashtag API")
+public class HashtagController {
+
+    private final HashtagQueryService hashtagQueryService;
+
+    @GetMapping("/recommendation")
+    @Operation(summary = "오늘의 옷(해시태그) 추천 조회", description = "해시태그와 각 해시태그에 맞는 옷 사진을 반환합니다.")
+    public CustomResponse<HashtagResponseDTO.DailyRecommendationListDTO> getRecommendation(
+            @RequestParam(value = "maxTemperature") int maxTemperature,
+            @RequestParam(value = "minTemperature") int minTemperature) {
+        return CustomResponse.onSuccess(hashtagQueryService.getRecommendation(maxTemperature, minTemperature));
+    }
+}

--- a/src/main/java/com/example/teamB/domain/hashtag/converter/HashtagConverter.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/converter/HashtagConverter.java
@@ -1,0 +1,22 @@
+package com.example.teamB.domain.hashtag.converter;
+
+import com.example.teamB.domain.hashtag.dto.HashtagResponseDTO;
+import com.example.teamB.domain.hashtag.entity.Hashtag;
+
+import java.util.List;
+
+public class HashtagConverter {
+
+    public static HashtagResponseDTO.DailyRecommendationDTO toDailyRecommendationDTO(Hashtag hashtag) {
+        return HashtagResponseDTO.DailyRecommendationDTO.builder()
+                .image(hashtag.getImage())
+                .hashtag(hashtag.getCategory().getKoreanName())
+                .build();
+    }
+
+    public static HashtagResponseDTO.DailyRecommendationListDTO toDailyRecommendationListDTO(List<Hashtag> hashtags) {
+        return HashtagResponseDTO.DailyRecommendationListDTO.builder()
+                .recommendations(hashtags.stream().map(HashtagConverter::toDailyRecommendationDTO).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/example/teamB/domain/hashtag/dto/HashtagResponseDTO.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/dto/HashtagResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.teamB.domain.hashtag.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class HashtagResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class DailyRecommendationDTO {
+        private String hashtag;
+        private String image;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class DailyRecommendationListDTO {
+        private List<DailyRecommendationDTO> recommendations;
+    }
+}

--- a/src/main/java/com/example/teamB/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/repository/HashtagRepository.java
@@ -4,8 +4,10 @@ import com.example.teamB.domain.hashtag.entity.Hashtag;
 import com.example.teamB.domain.hashtag.enums.HashtagCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     Optional<Hashtag> findByCategory(HashtagCategory category);
+    List<Hashtag> findByCategoryIn(List<HashtagCategory> categories);
 }

--- a/src/main/java/com/example/teamB/domain/hashtag/service/query/HashtagQueryService.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/service/query/HashtagQueryService.java
@@ -1,0 +1,7 @@
+package com.example.teamB.domain.hashtag.service.query;
+
+import com.example.teamB.domain.hashtag.dto.HashtagResponseDTO;
+
+public interface HashtagQueryService {
+    HashtagResponseDTO.DailyRecommendationListDTO getRecommendation(int maxTemperature, int minTemperature);
+}

--- a/src/main/java/com/example/teamB/domain/hashtag/service/query/HashtagQueryServiceImpl.java
+++ b/src/main/java/com/example/teamB/domain/hashtag/service/query/HashtagQueryServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.teamB.domain.hashtag.service.query;
+
+import com.example.teamB.domain.hashtag.converter.HashtagConverter;
+import com.example.teamB.domain.hashtag.dto.HashtagResponseDTO;
+import com.example.teamB.domain.hashtag.entity.Hashtag;
+import com.example.teamB.domain.hashtag.enums.HashtagCategory;
+import com.example.teamB.domain.hashtag.repository.HashtagRepository;
+import com.example.teamB.domain.ootd.provider.WeatherClassificationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HashtagQueryServiceImpl implements HashtagQueryService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Override
+    public HashtagResponseDTO.DailyRecommendationListDTO getRecommendation(int maxTemperature, int minTemperature) {
+        WeatherClassificationProvider weatherClassification
+                = WeatherClassificationProvider.getWeatherClassification(minTemperature, maxTemperature);
+        List<HashtagCategory> hashtagCategories = weatherClassification.provideRandomHashtags();
+
+        List<Hashtag> hashtags = hashtagRepository.findByCategoryIn(hashtagCategories);
+        return HashtagConverter.toDailyRecommendationListDTO(hashtags);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #22 

## 📌 개요
- 오늘의 옷(해시태그) 추천 조회 추가

## 🔁 변경 사항


## 📸 스크린샷
- 최고, 최저온도로 조회 (현재 더미 데이터가 없어 하나만 조회됩니다, 원래는 3개까지 나옵니다.)
![image](https://github.com/user-attachments/assets/57eedea6-5226-499c-9e41-8be7fda40aca)
![image](https://github.com/user-attachments/assets/a025d4f2-5660-4d3f-b706-5f90e1c9cd20)

## 👀 기타 더 이야기해볼 점
오늘의 옷(해시태그) 추천 조회 기능
해시태그와 각 해시태그에 맞는 옷 사진을 반환합니다 (최대 3개)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
